### PR TITLE
Relax spree_core version requirement

### DIFF
--- a/ship_fosdick.gemspec
+++ b/ship_fosdick.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'spree_core', '~> 2.4'
+  spec.add_dependency 'spree_core', '>= 2.4'
   spec.add_dependency 'nokogiri'
   spec.add_dependency 's3'
   spec.add_dependency 'httparty'


### PR DESCRIPTION
Require anything >= than 2.4 instead of only within the 2.4 series.

I don't know if other changes are required, I'm going to test that soon.